### PR TITLE
Updates to aliased action and translation create dialogs

### DIFF
--- a/src/components/AliasedActionCreateDialog.vue
+++ b/src/components/AliasedActionCreateDialog.vue
@@ -128,6 +128,13 @@
               </VCol>
             </VRow>
           </VForm>
+          <VAlert
+            type="warning"
+            v-if="initialAliasedActionKey && formAliasedActionKey !== initialAliasedActionKey"
+          >
+            Screens and Buttons reference Aliased Actions by their key. You should
+            not change an Aliased Action's key unless you know what you are doing.
+          </VAlert>
           <div class="action-btns lower-action-btns">
             <VBtn class="cancel-btn" @click="cancelClicked">
               Cancel

--- a/src/components/AliasedActionCreateDialog.vue
+++ b/src/components/AliasedActionCreateDialog.vue
@@ -185,7 +185,7 @@ export default {
     },
     initialActionArg: {
       type: String,
-      default: "/play "
+      default: "play "
     },
     initialHypixelBuildTeamAdminOnly: {
       type: Boolean,
@@ -287,7 +287,7 @@ export default {
         !this.formActionArg &&
         this.formActionType === "SendChatCommandAction"
       ) {
-        this.formActionArg = "/play ";
+        this.formActionArg = "play ";
       } else {
         this.formActionArg = "";
       }

--- a/src/components/AliasedActionsTable.vue
+++ b/src/components/AliasedActionsTable.vue
@@ -103,7 +103,7 @@ export default {
       editorInitialVisibleValue: true,
       editorInitialAdminOnlyValue: false,
       editorInitialActionType: "SendChatCommandAction",
-      editorInitialActionArg: "/play ",
+      editorInitialActionArg: "play ",
       editorInitialHypixelPackageRankRegex: "",
       editorInitialHypixelRankRegex: "",
       editorInitialHypixelLocrawRegex: "",
@@ -137,7 +137,7 @@ export default {
       this.editorInitialVisibleValue = true;
       this.editorInitialAdminOnlyValue = false;
       this.editorInitialActionType = "SendChatCommandAction";
-      this.editorInitialActionArg = "/play ";
+      this.editorInitialActionArg = "play ";
       this.editorInitialHypixelRankRegex = "";
       this.editorInitialHypixelPackageRankRegex = "";
       this.editorInitialHypixelLocrawRegex = {};

--- a/src/components/TranslationCreateDialog.vue
+++ b/src/components/TranslationCreateDialog.vue
@@ -107,11 +107,11 @@ export default {
     },
     initialTranslationKey: {
       type: String,
-      default: ""
+      default: "quickplay.games."
     },
     initialTranslationLang: {
       type: String,
-      default: ""
+      default: "en_us"
     },
     initialTranslationValue: {
       type: String,


### PR DESCRIPTION
Removed the / from the default "/play " on aliased actions
Added "quickplay.games." to the default key name
Added "en_us" to the default key language
Added an alert for when an aliased action's key is renamed, matching the already existing ones